### PR TITLE
uc-test-4 Update slider style to fill out all available screen space

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,10 @@ import { ImageSlider } from "./components/Slider/ImageSlider";
 import styled from "styled-components";
 
 function App() {
+  const height = window.innerHeight;
   return (
-    <StyledApp>
-      <ImageSlider loop autoPlay>
+    <StyledApp height={height}>
+      <ImageSlider loop>
         <ImageSlider.Slide src="https://image.isu.pub/200108033723-3ca2097884c8efacf45a0f28f2db9aff/jpg/page_109.jpg" />
         <ImageSlider.Slide src="https://w7.pngwing.com/pngs/31/751/png-transparent-museum-of-modern-art-futurism-bauhaus-typography-poster-number-2-food-text-monochrome-thumbnail.png" />
         <ImageSlider.Slide src="https://www.accobrands.com.au/pa_images/Detail/900408.jpg" />
@@ -17,9 +18,9 @@ function App() {
   );
 }
 
-const StyledApp = styled.div`
+const StyledApp = styled.div<{ height: number }>`
   width: 100vw;
-  height: 100vh;
+  height: ${({ height }) => `${height}px`};
 `;
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,25 @@
 import "./App.css";
 import { ImageSlider } from "./components/Slider/ImageSlider";
+import styled from "styled-components";
 
 function App() {
   return (
-    <ImageSlider loop autoPlay>
-      <ImageSlider.Slide src="https://image.isu.pub/200108033723-3ca2097884c8efacf45a0f28f2db9aff/jpg/page_109.jpg" />
-      <ImageSlider.Slide src="https://w7.pngwing.com/pngs/31/751/png-transparent-museum-of-modern-art-futurism-bauhaus-typography-poster-number-2-food-text-monochrome-thumbnail.png" />
-      <ImageSlider.Slide src="https://www.accobrands.com.au/pa_images/Detail/900408.jpg" />
-      <ImageSlider.Slide src="https://lh3.googleusercontent.com/Y2-c97PxIFWROK24rVVGaIzF2lngG_8iXYZgNYvq7jb-7_-LLzmQP_o1fuxAw9xSovXwc8F5giWzUAJ75-YW9lNiH79XAAteSLPXDaY=s120" />
-      <ImageSlider.Slide src="https://ukrpublic.com/images/2021/09/16/73378738_large.jpg" />
-      <ImageSlider.Slide src="https://otvet.imgsmail.ru/download/875a8375f91de049494d6073098e8a2f_87df8602575cc25864a612668335e50b.png" />
-    </ImageSlider>
+    <StyledApp>
+      <ImageSlider loop autoPlay>
+        <ImageSlider.Slide src="https://image.isu.pub/200108033723-3ca2097884c8efacf45a0f28f2db9aff/jpg/page_109.jpg" />
+        <ImageSlider.Slide src="https://w7.pngwing.com/pngs/31/751/png-transparent-museum-of-modern-art-futurism-bauhaus-typography-poster-number-2-food-text-monochrome-thumbnail.png" />
+        <ImageSlider.Slide src="https://www.accobrands.com.au/pa_images/Detail/900408.jpg" />
+        <ImageSlider.Slide src="https://lh3.googleusercontent.com/Y2-c97PxIFWROK24rVVGaIzF2lngG_8iXYZgNYvq7jb-7_-LLzmQP_o1fuxAw9xSovXwc8F5giWzUAJ75-YW9lNiH79XAAteSLPXDaY=s120" />
+        <ImageSlider.Slide src="https://ukrpublic.com/images/2021/09/16/73378738_large.jpg" />
+        <ImageSlider.Slide src="https://otvet.imgsmail.ru/download/875a8375f91de049494d6073098e8a2f_87df8602575cc25864a612668335e50b.png" />
+      </ImageSlider>
+    </StyledApp>
   );
 }
+
+const StyledApp = styled.div`
+  width: 100vw;
+  height: 100vh;
+`;
 
 export default App;

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -13,6 +13,7 @@ interface Props extends PropsWithChildren {
   vertical?: boolean;
   gap?: number;
   center?: boolean;
+  fullSize?: boolean;
   onClick?: MouseEventHandler;
   onKeyDown?: KeyboardEventHandler;
 }
@@ -25,6 +26,7 @@ const Container: FC<Props> = (props) => (
     gap={props.gap}
     center={props.center}
     onClick={props.onClick}
+    fullSize={props.fullSize}
     onKeyDown={props.onKeyDown}
   >
     {props.children}
@@ -32,7 +34,8 @@ const Container: FC<Props> = (props) => (
 );
 
 const StyledContainer = styled.div<Props>`
-  width: fit-content;
+  ${({ fullSize }) =>
+    fullSize ? "width: 100%; height: 100%" : "width: fit-content;"};
 
   display: flex;
   flex-direction: ${(props) => (props.vertical ? "column" : "row")};

--- a/src/components/Slider/ImageSlider.tsx
+++ b/src/components/Slider/ImageSlider.tsx
@@ -99,7 +99,7 @@ const ImageSlider: FC<Props> & ImageSliderExtensions = (props) => {
         isForward ? (j -= 1) : (j += 1)
       ) {
         setCurrentImgIdx(j);
-        await new Promise((resolve) => setTimeout(resolve, 40 * j));
+        await new Promise((resolve) => setTimeout(resolve, 40));
       }
     } else {
       setCurrentImgIdx(i);
@@ -107,76 +107,71 @@ const ImageSlider: FC<Props> & ImageSliderExtensions = (props) => {
   };
 
   return (
-    <Container vertical center gap={40}>
-      <Container vertical gap={10} center>
-        <Container center gap={10}>
-          {children.length > 1 && (
-            <Button
-              disabled={!(currentImgIdx > 0 || props.loop)}
-              onClick={setPrevImg}
-            >
-              &lt;
-            </Button>
-          )}
-          <ImageSet
-            tabIndex={-1}
-            ref={imageSetRef}
-            onKeyDown={(e) => handleKeyDown(e.key)}
-            onTouchStart={(e) => setTouchStart(e.targetTouches[0].clientX)}
-            onTouchMove={(e) => setTouchEnd(e.targetTouches[0].clientX)}
-            onTouchEnd={handleSwipe}
+    <Container vertical gap={10} center fullSize>
+      <Container center gap={10} fullSize>
+        {children.length > 1 && (
+          <Button
+            disabled={!(currentImgIdx > 0 || props.loop)}
+            onClick={setPrevImg}
           >
-            {children.length > 1 && (
-              <Image
-                style={{ transform: "translateX(-400px)" }}
-                key={prevImgIndex}
-              >
-                {children[prevImgIndex]}
-              </Image>
-            )}
-            <Image
-              onMouseEnter={() => {
-                if (props.autoPlay) {
-                  stopAutoPlay();
-                }
-              }}
-              onMouseLeave={() => {
-                if (props.autoPlay) {
-                  startAutoPlay();
-                }
-              }}
-              key={currentImgIdx}
-            >
-              {children[currentImgIdx]}
-            </Image>
-            {children.length > 1 && (
-              <Image
-                style={{ transform: "translateX(400px)" }}
-                key={nextImgIndex}
-              >
-                {children[nextImgIndex]}
-              </Image>
-            )}
-          </ImageSet>
+            &lt;
+          </Button>
+        )}
+        <ImageSet
+          tabIndex={-1}
+          ref={imageSetRef}
+          onKeyDown={(e) => handleKeyDown(e.key)}
+          onTouchStart={(e) => setTouchStart(e.targetTouches[0].clientX)}
+          onTouchMove={(e) => setTouchEnd(e.targetTouches[0].clientX)}
+          onTouchEnd={handleSwipe}
+        >
           {children.length > 1 && (
-            <Button
-              disabled={!(currentImgIdx < children.length - 1 || props.loop)}
-              onClick={setNextImg}
+            <Image
+              style={{ transform: "translateX(-100%)" }}
+              key={prevImgIndex}
             >
-              &gt;
-            </Button>
+              {children[prevImgIndex]}
+            </Image>
           )}
-        </Container>
-        <Container gap={10}>
-          {children.map((_, i) => (
-            <Dot
-              onClick={() => handleDotClick(i)}
-              key={i}
-              accent={i === currentImgIdx}
-            />
-          ))}
-        </Container>
+          <Image
+            onMouseEnter={() => {
+              if (props.autoPlay) {
+                stopAutoPlay();
+              }
+            }}
+            onMouseLeave={() => {
+              if (props.autoPlay) {
+                startAutoPlay();
+              }
+            }}
+            key={currentImgIdx}
+          >
+            {children[currentImgIdx]}
+          </Image>
+          {children.length > 1 && (
+            <Image style={{ transform: "translateX(100%)" }} key={nextImgIndex}>
+              {children[nextImgIndex]}
+            </Image>
+          )}
+        </ImageSet>
+        {children.length > 1 && (
+          <Button
+            disabled={!(currentImgIdx < children.length - 1 || props.loop)}
+            onClick={setNextImg}
+          >
+            &gt;
+          </Button>
+        )}
       </Container>
+      <DotsContainer gap={10}>
+        {children.map((_, i) => (
+          <Dot
+            onClick={() => handleDotClick(i)}
+            key={i}
+            accent={i === currentImgIdx}
+          />
+        ))}
+      </DotsContainer>
     </Container>
   );
 };
@@ -188,10 +183,14 @@ const Slide: FC<SlideProps> = (props) => {
   return <SlideImage src={props.src} />;
 };
 
+const DotsContainer = styled(Container)`
+  padding: 20px 0;
+`;
+
 const ImageSet = styled.div`
   position: relative;
-  width: 250px;
-  height: 200px;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   overflow: hidden;
@@ -202,6 +201,7 @@ const Image = styled.div`
   position: absolute;
   width: 100%;
   height: 100%;
+  flex-shrink: 0;
   transition: transform 0.4s ease-in-out;
 `;
 

--- a/src/index.css
+++ b/src/index.css
@@ -28,7 +28,6 @@ body {
   display: flex;
   place-items: center;
   min-width: 320px;
-  min-height: 100vh;
 }
 
 h1 {


### PR DESCRIPTION
For making ImageSlider to fill out all available screen space I have provided it some parent with fixed size equals to screen size and then made slider size relative (%) to the size of the parent.

Since ImageSlider contains  some `Containers` to display its content, these Containers also need to be able to to fill out all available space of their parents, so they have the `fullSize` property now.

Some fixed sizes of elements (200px, 400px...) changed to relative (%) including  the value of the `translateX` property of  element with image (`Image`).

Since `Image` element is a part of a flex-container, it needs the `flex-shrink` property with `0` value so it isn't constricted and really has 100% available width of that flex-container.




I have also added some padding to the element that contains `Dots` and made smoother the animation of changing between images that far from each other more than 1 image.